### PR TITLE
FEAT: Add new sites:listcacherules command to get all cache rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 composer.lock
 .php_cs.cache
 vendor
+.idea/

--- a/README.md
+++ b/README.md
@@ -12,7 +12,11 @@ Currently only a few commands are available. This is currently a work in progres
 
 ## Installation
 
-TODO
+1. Clone the repo locally: `git clone git@github.com:halkyon/incapsula-php.git`.
+2. Run `composer install` to install dependencies.
+3. Configure your Incapsula API credentials (see below).
+4. Test your credentials using the `./bin/incapsula sites:list` command
+5. See a list of all commands you can run by calling `./bin/incapsula`
 
 ## Configuring credentials
 
@@ -20,6 +24,11 @@ You can define credentials either as environment variables `INCAPSULA_API_ID` an
 or as a credential file located in the current user home directory `~/.incapsula/credentials`.
 
 Order of preference is environment variables first, then ini file.
+
+Note: Environment variables must be actually set as env vars, not just added in a `.env` file in the application root.
+
+If you're confident about the security of your machine, you can define them on the command-line, for example:
+`INCAPSULA_API_ID=ABC123 INCAPSULA_API_KEY=xyz789 ./bin/incapsula sites:list` 
 
 Example ini file:
 ```
@@ -51,6 +60,11 @@ incapsula integration:ips
 incapsula sites:list
 ```
 
+### List all cache rules for all sites
+
+```
+incapsula sites:listcacherules
+```
 ### Upload custom certificate
 
 ```
@@ -91,3 +105,7 @@ $ips = $client->integration()->ips();
 var_dump($ips['ipRanges']);
 var_dump($ips['ipv6Ranges']);
 ```
+
+## Contributing
+
+Before making a pull request, please run the code syntax fixer to make sure the linter works: `vendor/bin/php-cs-fixer fix`.

--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
     "name": "halkyon/incapsula-php",
     "require": {
         "php": ">=7.1",
+        "ext-json": "*",
         "guzzlehttp/guzzle": "^6.0",
         "symfony/console": "^3.0",
         "symfony/finder": "^3.0"

--- a/src/Api/SitesApi.php
+++ b/src/Api/SitesApi.php
@@ -102,4 +102,22 @@ class SitesApi extends AbstractApi
             'destination_account_id' => $destAccountId,
         ]);
     }
+
+    /**
+     * @param int $siteId   The site ID to retrieve all cache rules for
+     * @param int $pageSize The number of rules to return per page
+     * @param int $pageNum  The page number to return (if more than one page of results)
+     *
+     * @throws \Exception
+     *
+     * @return array
+     */
+    public function listCacheRules($siteId, $pageSize = 50, $pageNum = 0)
+    {
+        return $this->client->sendRaw(sprintf('%s/performance/caching-rules/list', $this->apiUri), [
+            'site_id' => $siteId,
+            'page_size' => $pageSize,
+            'page_num' => $pageNum,
+        ]);
+    }
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -95,6 +95,30 @@ class Client
      */
     public function send($uri, $params = [], $headers = [])
     {
+        $data = $this->sendRaw($uri, $params, $headers);
+
+        if (0 !== $data['res']) {
+            throw new Exception(sprintf('Bad response: %s (code: %s)', $data['res_message'], $data['res']));
+        }
+
+        return $data;
+    }
+
+    /**
+     * Sends a request to the Incapsula API and returns the raw response (with no checking or parsing done, beyond
+     * ensuring there was at least *some* response). Useful for when the API endpoint does not implement the expected
+     * 'res' structure expected by self::send().
+     *
+     * @param string $uri
+     * @param array  $params
+     * @param array  $headers
+     *
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     *
+     * @return array
+     */
+    public function sendRaw($uri, $params = [], $headers = [])
+    {
         // apply credentials to all api calls except integration/ips, which doesn't require them.
         if (false === strpos($uri, 'integration/ips')) {
             $params = array_merge($params, [
@@ -109,9 +133,6 @@ class Client
 
         if (null === $data) {
             throw new Exception(sprintf('Could not parse JSON (code: %s)', json_last_error()));
-        }
-        if (0 !== $data['res']) {
-            throw new Exception(sprintf('Bad response: %s (code: %s)', $data['res_message'], $data['res']));
         }
 
         return $data;

--- a/src/Command/ListAllCacheRulesCommand.php
+++ b/src/Command/ListAllCacheRulesCommand.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Incapsula\Command;
+
+use function json_encode;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ListAllCacheRulesCommand extends SitesListCommand
+{
+    protected function configure()
+    {
+        parent::configure();
+
+        $this
+            ->setName('sites:listcacherules')
+            ->addOption('json', null, InputOption::VALUE_NONE, 'Output as JSON')
+            ->setDescription('List all cache rules for all sites');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $rules = $this->getRules();
+
+        if (true === $input->getOption('json')) {
+            $output->write(json_encode($rules));
+
+            return 0;
+        }
+
+        $table = new Table($output);
+        $table->setHeaders(['Site ID', 'Site Name', 'Rule ID', 'Action', 'Disabled?', 'Rule Name', 'Rule Filter', 'TTL']);
+
+        foreach ($rules as $rule) {
+            $table->addRow([
+                $rule['site_id'],
+                $rule['site_name'],
+                $rule['rule_id'],
+                $rule['action'],
+                $rule['disabled'],
+                $rule['name'],
+                $rule['filter'],
+                $rule['ttl'],
+            ]);
+        }
+
+        $table->render();
+
+        return 0;
+    }
+
+    private function getRules()
+    {
+        $api = $this->client->sites();
+        $sites = $this->getSites();
+        $rules = [];
+
+        foreach ($sites as $site) {
+            $page = 0;
+            while (true) {
+                $response = $api->listCacheRules($site['site_id'], 50, $page);
+
+                if (empty($response)) {
+                    break;
+                }
+
+                foreach ($response as $ruleType => $rulesOfType) {
+                    foreach ($rulesOfType as $ruleData) {
+                        $ttl = '';
+
+                        if (isset($ruleData['ttl'], $ruleData['ttlUnit'])) {
+                            $ttl = sprintf('%s %s', $ruleData['ttl'], $ruleData['ttlUnit']);
+                        }
+
+                        $rules[] = [
+                            'site_id' => $site['site_id'],
+                            'site_name' => $site['display_name'],
+                            'rule_id' => $ruleData['id'],
+                            'action' => $ruleType,
+                            'disabled' => $ruleData['disabled'],
+                            'name' => $ruleData['name'],
+                            'filter' => $ruleData['filter'],
+                            'ttl' => $ttl,
+                        ];
+                    }
+                }
+
+                ++$page;
+            }
+        }
+
+        return $rules;
+    }
+}

--- a/src/Command/SitesListCommand.php
+++ b/src/Command/SitesListCommand.php
@@ -28,18 +28,7 @@ class SitesListCommand extends AbstractCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $api = $this->client->sites();
-        $sites = [];
-        $page = 0;
-
-        while (true) {
-            $resp = $api->list(50, $page);
-            if (empty($resp['sites'])) {
-                break;
-            }
-            $sites = array_merge($sites, $resp['sites']);
-            ++$page;
-        }
+        $sites = $this->getSites();
 
         if (true === $input->getOption('json')) {
             $output->write(json_encode($sites));
@@ -55,5 +44,23 @@ class SitesListCommand extends AbstractCommand
         $table->render();
 
         return 0;
+    }
+
+    protected function getSites()
+    {
+        $api = $this->client->sites();
+        $sites = [];
+        $page = 0;
+
+        while (true) {
+            $resp = $api->list(50, $page);
+            if (empty($resp['sites'])) {
+                break;
+            }
+            $sites = array_merge($sites, $resp['sites']);
+            ++$page;
+        }
+
+        return $sites;
     }
 }


### PR DESCRIPTION
[API] Add new ListAllCacheRulesCommand (aka sites:listcacherules)
[API] Add new Client->sendRaw() command to allow for API calls that don't return data in the expected 'res' structure
[API] Add new SitesApi->listCacheRules() method

[MINOR] Update SitesListCommand to use a getSites() method so the ListAllCacheRulesCommand can use it as well
[MINOR] Ensure we require ext-json PHP module
[MINOR] Add PHPStorm folder to .gitignore

[DOCS] Add install tips and a note on environment variables