### PR TITLE
Dynamic cache audit

### DIFF
--- a/src/Api/SitesApi.php
+++ b/src/Api/SitesApi.php
@@ -29,7 +29,17 @@ class SitesApi extends AbstractApi
     {
         return $this->client->send(sprintf('%s/add', $this->apiUri), $params);
     }
-
+    /**
+     * @param string $siteId
+     *
+     * @return array
+     */
+    public function status($siteId)
+    {
+        return $this->client->send(sprintf('%s/status', $this->apiUri), [
+            'site_id' => $siteId,
+        ]);
+    }
     /**
      * @param string $siteId
      *
@@ -118,6 +128,19 @@ class SitesApi extends AbstractApi
             'site_id' => $siteId,
             'page_size' => $pageSize,
             'page_num' => $pageNum,
+        ]);
+    }
+
+        /**
+     * @param array $params
+     *
+     * @return array
+     */
+    public function setStaticCacheMode($siteId)
+    {
+        return $this->client->send(sprintf('%s/performance/cache-mode', $this->apiUri), [
+            'site_id' => $siteId,
+            'cache_mode' => 'static_only',
         ]);
     }
 }

--- a/src/Command/SetAllCacheModeCommand.php
+++ b/src/Command/SetAllCacheModeCommand.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Incapsula\Command;
+
+use function json_encode;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class SetAllCacheModeCommand extends SitesListCommand
+{
+    protected function configure()
+    {
+        parent::configure();
+
+        $this
+            ->setName('sites:setCacheMode')
+            ->addOption('json', null, InputOption::VALUE_NONE, 'Output as JSON')
+            ->setDescription('List all cache rules for all sites');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $changes = $this->setCacheMode();
+
+        if (true === $input->getOption('json')) {
+            $output->write(json_encode($changes));
+
+            return 0;
+        }
+
+        $output->writeln("sites that were changed in this run");
+        $table = new Table($output);
+        $table->setHeaders(['Site ID', 'Site Name','Return Message']);
+
+        foreach ($changes as $changed) {
+            $table->addRow([
+                $changed['site_id'],
+                $changed['domain'],
+                $changed['return'],
+            ]);
+        }
+
+        $table->render();
+
+        return 0;
+    }
+
+    private function setCacheMode()
+    {
+        $api = $this->client->sites();
+        $sites = $this->getSites();
+        $changed = [];
+        foreach ($sites as $site) {
+            $return_val = $this->client->sites()->setStaticCacheMode($site['site_id']);
+            $mode = $site['acceleration_level'];
+            if ($mode==='advanced'){
+                array_push($changed,[
+                    'site_id' => $site['site_id'],
+                    'domain' => $site['domain'],
+                    'return' => $return_val['res_message'],
+                    ]);
+            }
+        }
+
+        return $changed;
+    }
+}

--- a/src/Command/SetStaticCacheModeCommand.php
+++ b/src/Command/SetStaticCacheModeCommand.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Incapsula\Command;
+
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class SetStaticCacheModeCommand extends AbstractCommand
+{
+    /**
+     * @var string
+     */
+    private $siteId;
+
+    /**
+     * @var string
+     */
+    private $certificatePath;
+
+    /**
+     * @var string
+     */
+    private $privateKeyPath;
+
+    protected function configure()
+    {
+        parent::configure();
+
+        $this
+            ->setName('StaticCacheMode:set')
+            ->addArgument('site-id', InputArgument::REQUIRED, 'Site ID')
+            ->setDescription('Ensure a site is in static caching header mode')
+        ;
+    }
+
+    /**
+     * @param InputInterface  $input
+     * @param OutputInterface $output
+     */
+    protected function initialize(InputInterface $input, OutputInterface $output)
+    {
+        parent::initialize($input, $output);
+
+        $this->siteId = $input->getArgument('site-id');
+    }
+
+    /**
+     * @param InputInterface  $input
+     * @param OutputInterface $output
+     *
+     * @return int
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $return_val = $this->client->sites()->setStaticCacheMode(
+            $this->siteId
+        );
+
+        return $return_val;
+    }
+}

--- a/src/Command/SitesListAttributeCommand.php
+++ b/src/Command/SitesListAttributeCommand.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Incapsula\Command;
+
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class SitesListAttributeCommand extends AbstractCommand
+{
+    protected function configure()
+    {
+        parent::configure();
+
+        $this
+            ->setName('sites:listattribute')
+            ->addOption('attribute',null,InputOption::VALUE_REQUIRED, 'json key to inspect')
+            ->addOption('json', null, InputOption::VALUE_NONE, 'Output as JSON')
+            ->setDescription('List a config value from all sites')
+        ;
+    }
+
+    /**
+     * @param InputInterface  $input
+     * @param OutputInterface $output
+     *
+     * @return int
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $attribute = $input->getOption('attribute');
+
+        $sites = $this->getSites();
+
+        if (true === $input->getOption('json')) {
+            $output->write(json_encode($sites));
+
+            return 0;
+        }
+
+        $table = new Table($output);
+        $table->setHeaders(['Site ID', 'Domain', 'Attribute']);
+        foreach ($sites as $site) {
+            $table->addRow([$site['site_id'], $site['domain'], $site[$attribute]]);
+        }
+        $table->render();
+
+        return 0;
+    }
+
+    protected function getSites()
+    {
+        $api = $this->client->sites();
+        $sites = [];
+        $page = 0;
+
+        while (true) {
+            $resp = $api->list(50, $page);
+            if (empty($resp['sites'])) {
+                break;
+            }
+            $sites = array_merge($sites, $resp['sites']);
+            ++$page;
+        }
+
+        return $sites;
+    }
+}

--- a/src/Command/SitesListAttributeCommand.php
+++ b/src/Command/SitesListAttributeCommand.php
@@ -16,7 +16,6 @@ class SitesListAttributeCommand extends AbstractCommand
         $this
             ->setName('sites:listattribute')
             ->addOption('attribute',null,InputOption::VALUE_REQUIRED, 'json key to inspect')
-            ->addOption('json', null, InputOption::VALUE_NONE, 'Output as JSON')
             ->setDescription('List a config value from all sites')
         ;
     }
@@ -32,12 +31,6 @@ class SitesListAttributeCommand extends AbstractCommand
         $attribute = $input->getOption('attribute');
 
         $sites = $this->getSites();
-
-        if (true === $input->getOption('json')) {
-            $output->write(json_encode($sites));
-
-            return 0;
-        }
 
         $table = new Table($output);
         $table->setHeaders(['Site ID', 'Domain', 'Attribute']);


### PR DESCRIPTION
:wave: 
Howdy
this PR is for a cache audit that we needed to do to close a problem ticket related to bad incapsula config.
I've run in prod so it's definitely working
here's some sample output:
```
sites that were changed in this run
+----------+-----------------------------------+----------------+
| Site ID  | Site Name                         | Return Message |
+----------+-----------------------------------+----------------+
| 77777777 | importantwebsite.biz | OK             |
+----------+-----------------------------------+----------------+

```